### PR TITLE
removing user_id from tasks table and add it to competitions_tasks

### DIFF
--- a/app/models/competitions_task.rb
+++ b/app/models/competitions_task.rb
@@ -1,4 +1,6 @@
 class CompetitionsTask < ApplicationRecord
   belongs_to :task
   belongs_to :competition
+  belongs_to :user, optional: true
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,7 @@ class User < ApplicationRecord
   has_many :scores
   has_many :competitions
   has_many :tasks
+  has_many :competitions_tasks
 
   has_one :couple
 end

--- a/db/migrate/20230917132958_remove_user_from_tasks.rb
+++ b/db/migrate/20230917132958_remove_user_from_tasks.rb
@@ -1,0 +1,5 @@
+class RemoveUserFromTasks < ActiveRecord::Migration[7.0]
+  def change
+    remove_reference :tasks, :user, null: false, foreign_key: true
+  end
+end

--- a/db/migrate/20230917133203_add_user_to_competitions_tasks.rb
+++ b/db/migrate/20230917133203_add_user_to_competitions_tasks.rb
@@ -1,0 +1,5 @@
+class AddUserToCompetitionsTasks < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :competitions_tasks, :user, null: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_13_193044) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_17_133203) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -32,8 +32,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_13_193044) do
     t.boolean "is_done", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id"
     t.index ["competition_id"], name: "index_competitions_tasks_on_competition_id"
     t.index ["task_id"], name: "index_competitions_tasks_on_task_id"
+    t.index ["user_id"], name: "index_competitions_tasks_on_user_id"
   end
 
   create_table "couples", force: :cascade do |t|
@@ -90,12 +92,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_13_193044) do
     t.string "content"
     t.date "deadline"
     t.boolean "is_recurent", default: false
-    t.bigint "user_id"
     t.bigint "kid_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["kid_id"], name: "index_tasks_on_kid_id"
-    t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -118,6 +118,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_13_193044) do
   add_foreign_key "competitions", "users"
   add_foreign_key "competitions_tasks", "competitions"
   add_foreign_key "competitions_tasks", "tasks"
+  add_foreign_key "competitions_tasks", "users"
   add_foreign_key "events", "competitions"
   add_foreign_key "events", "kids"
   add_foreign_key "events", "users"
@@ -126,6 +127,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_13_193044) do
   add_foreign_key "scores", "competitions"
   add_foreign_key "scores", "users"
   add_foreign_key "tasks", "kids"
-  add_foreign_key "tasks", "users"
   add_foreign_key "users", "couples"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -264,14 +264,14 @@ Couple.all.each do |couple|
         content: Faker::Lorem.paragraph(sentence_count: rand(2..8)),
         deadline: task_deadline,
         is_recurent: rand(5).zero?,
-        user: winner || nil,
         kid: couple.kids.sample
       )
 
       CompetitionsTask.create!(
         task: task,
         competition: competition,
-        is_done: competition.user == true
+        is_done: competition.user == true,
+        user: winner || nil
       )
     end
 


### PR DESCRIPTION
The tasks table had an user_id reference to identify who pick the task

The issue was that a task can be recurrent so has to live independently from any competitions

That's why we need to move the assignement of a task in the table that join competitions and tasks => competitions_tasks table 